### PR TITLE
[codex] pin mutable docker image tags

### DIFF
--- a/home-assistant/docker-compose.yml
+++ b/home-assistant/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
 services:
   ha:
     profiles: [service]
-    image: homeassistant/home-assistant:latest
+    image: homeassistant/home-assistant:2026.4.1
     volumes:
       - ha_config:/config
       - /etc/localtime:/etc/localtime:ro

--- a/services/immich.yml
+++ b/services/immich.yml
@@ -2,7 +2,7 @@
 services:
   immich-postgres:
     profiles: [apps, all]
-    image: pgvector/pgvector:pg17
+    image: pgvector/pgvector:0.8.2-pg17
     environment:
       - POSTGRES_USER=${DB_USERNAME:-immich}
       - POSTGRES_PASSWORD=${DB_PASSWORD:-immich}
@@ -34,7 +34,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    image: ghcr.io/immich-app/immich-server:release
+    image: ghcr.io/immich-app/immich-server:v2.7.3
     command: [start.sh, immich]
     volumes: [immich_library:/usr/src/app/upload]
     environment:
@@ -75,7 +75,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    image: ghcr.io/immich-app/immich-server:release
+    image: ghcr.io/immich-app/immich-server:v2.7.3
     command: [start.sh, microservices]
     volumes: [immich_library:/usr/src/app/upload]
     environment:
@@ -106,7 +106,7 @@ services:
   # ML processing - Sablier-managed group (queue wake is experimental)
   immich-machine-learning:
     profiles: [apps, all]
-    image: ghcr.io/immich-app/immich-machine-learning:release
+    image: ghcr.io/immich-app/immich-machine-learning:v2.7.3
     volumes: [immich_model_cache:/cache]
     environment: [REDIS_HOSTNAME=redis]
     networks: [immich]
@@ -130,7 +130,7 @@ services:
   # Queue storage - Always on
   redis:
     profiles: [apps, all]
-    image: redis:7-alpine
+    image: redis:7.4.8-alpine3.21
     volumes: [immich_redis:/data]
     networks: [immich]
     healthcheck:
@@ -151,7 +151,7 @@ services:
   # Queue monitor (experimental) - Polls Redis, pings Sablier API
   immich-queue-monitor:
     profiles: [experimental]
-    image: alpine:latest
+    image: alpine:3.23.3
     depends_on: [redis]
     environment:
       - REDIS_HOST=redis

--- a/services/karakeep.yml
+++ b/services/karakeep.yml
@@ -2,7 +2,7 @@
 services:
   keep:
     profiles: [apps, all]
-    image: ghcr.io/karakeep-app/karakeep:release
+    image: ghcr.io/karakeep-app/karakeep:0.31.0
     restart: always
     depends_on:
       chrome:
@@ -33,7 +33,7 @@ services:
           memory: 256M
   chrome:
     profiles: [apps, all]
-    image: gcr.io/zenika-hub/alpine-chrome:124
+    image: gcr.io/zenika-hub/alpine-chrome@sha256:1a0046448e0bb6c275c88f86e01faf0de62b02ec8572901256ada0a8c08be23f
     restart: always
     networks: [keep]
     command:

--- a/services/listmonk.yml
+++ b/services/listmonk.yml
@@ -2,7 +2,7 @@
 services:
   listmonk-postgres:
     profiles: [apps, all]
-    image: postgres:17-alpine
+    image: postgres:17.9-alpine3.23
     environment:
       - POSTGRES_USER=${LISTMONK_db__user:-listmonk}
       - POSTGRES_PASSWORD=${LISTMONK_db__password:-dummy_password}
@@ -27,7 +27,7 @@ services:
           memory: 256M
   listmonk:
     profiles: [apps, all]
-    image: listmonk/listmonk:latest
+    image: listmonk/listmonk:v6.1.0
     depends_on:
       listmonk-postgres:
         condition: service_healthy

--- a/services/media.yml
+++ b/services/media.yml
@@ -2,7 +2,7 @@
 services:
   gluetun:
     profiles: [apps, all]
-    image: qmcgaw/gluetun:latest
+    image: qmcgaw/gluetun:v3.41.1
     cap_add: [NET_ADMIN]
     devices: [/dev/net/tun:/dev/net/tun]
     networks: [media]
@@ -25,7 +25,7 @@ services:
           memory: 256M
   jellyfin:
     profiles: [apps, all]
-    image: jellyfin/jellyfin:latest
+    image: jellyfin/jellyfin:10.11.8
     networks: [traefik_public, media]
     volumes:
       - jellyfin_config:/config
@@ -53,7 +53,7 @@ services:
           memory: 512M
   seerr:
     profiles: [apps, all]
-    image: ghcr.io/seerr-team/seerr:latest
+    image: ghcr.io/seerr-team/seerr:v3.1.0
     init: true
     networks: [traefik_public, media]
     environment: [TZ=Europe/Copenhagen, LOG_LEVEL=info, PORT=5055]
@@ -89,7 +89,7 @@ services:
           memory: 256M
   qbittorrent:
     profiles: [apps, all]
-    image: lscr.io/linuxserver/qbittorrent:latest
+    image: lscr.io/linuxserver/qbittorrent:5.1.4-r2-ls448
     network_mode: service:gluetun
     depends_on: [gluetun]
     environment:
@@ -110,7 +110,7 @@ services:
           memory: 512M
   sonarr:
     profiles: [apps, all]
-    image: lscr.io/linuxserver/sonarr:latest
+    image: lscr.io/linuxserver/sonarr:4.0.17.2952-ls306
     network_mode: service:gluetun
     depends_on: [gluetun, qbittorrent]
     environment:
@@ -129,7 +129,7 @@ services:
           memory: 256M
   radarr:
     profiles: [apps, all]
-    image: lscr.io/linuxserver/radarr:latest
+    image: lscr.io/linuxserver/radarr:6.1.1.10360-ls298
     network_mode: service:gluetun
     depends_on: [gluetun, qbittorrent]
     environment:

--- a/services/networking.yml
+++ b/services/networking.yml
@@ -70,7 +70,7 @@ services:
           memory: 64M
   whoami:
     profiles: [infra, all]
-    image: traefik/whoami:v1.10
+    image: traefik/whoami:v1.10.4
     depends_on:
       traefik:
         condition: service_healthy
@@ -132,7 +132,7 @@ services:
           memory: 128M
   netalertx:
     profiles: [infra, all]
-    image: ghcr.io/jokob-sk/netalertx:latest
+    image: ghcr.io/jokob-sk/netalertx:26.4.6
     network_mode: host
     depends_on:
       traefik:

--- a/services/paperless-ngx.yml
+++ b/services/paperless-ngx.yml
@@ -2,7 +2,7 @@
 services:
   paperless-postgres:
     profiles: [apps, all]
-    image: postgres:17-alpine
+    image: postgres:17.9-alpine3.23
     restart: always
     networks: [paperless]
     volumes: [paperless_postgres_data:/var/lib/postgresql/data]
@@ -115,7 +115,7 @@ services:
           memory: 512M
   paperless-redis:
     profiles: [apps, all]
-    image: redis:7-alpine
+    image: redis:7.4.8-alpine3.21
     restart: always
     networks: [paperless]
     volumes: [paperless_redis:/data]
@@ -134,7 +134,7 @@ services:
           memory: 128M
   paperless-gotenberg:
     profiles: [apps, all]
-    image: gotenberg/gotenberg:8
+    image: gotenberg/gotenberg:8.30.1
     restart: always
     networks: [paperless]
     command:

--- a/services/pods.yml
+++ b/services/pods.yml
@@ -30,7 +30,7 @@ services:
           memory: 256M
   dockhand:
     profiles: [apps, all, pods]
-    image: fnsys/dockhand:latest
+    image: fnsys/dockhand:v1.0.24
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - dockhand_data:/app/data

--- a/services/rustfs.yml
+++ b/services/rustfs.yml
@@ -2,7 +2,7 @@
 services:
   rustfs:
     profiles: [infra, all]
-    image: rustfs/rustfs:latest
+    image: rustfs/rustfs:1.0.0-alpha.92
     depends_on:
       traefik:
         condition: service_healthy

--- a/services/speedtest-tracker.yml
+++ b/services/speedtest-tracker.yml
@@ -2,7 +2,7 @@
 services:
   speedtest-tracker:
     profiles: [apps, all]
-    image: lscr.io/linuxserver/speedtest-tracker:latest
+    image: lscr.io/linuxserver/speedtest-tracker:v1.13.12-ls144
     restart: always
     env_file: [.env-speedtest-tracker]
     environment:

--- a/services/teable-migrate.yml
+++ b/services/teable-migrate.yml
@@ -1,7 +1,7 @@
 ---
 services:
   teable-createbuckets:
-    image: minio/mc
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     env_file: [./.env-teable]
     entrypoint: >
       /bin/sh -c "
@@ -17,7 +17,7 @@ services:
       restart_policy:
         condition: none  # Ensures the service does not restart
   teable-db-migrate:
-    image: ghcr.io/teableio/teable-db-migrate:latest
+    image: ghcr.io/teableio/teable-db-migrate@sha256:f046bef9c10888af0fc3e78c92dda8d47fe8ffdc09b3fb77cc2c298253dd3e2d
     env_file: [./.env-teable]
     deploy:
       replicas: 1  # Ensures only one instance runs

--- a/services/teable.yml
+++ b/services/teable.yml
@@ -1,7 +1,7 @@
 ---
 services:
   teable:
-    image: ghcr.io/teableio/teable:latest
+    image: ghcr.io/teableio/teable@sha256:36b47d022333148903ca0ec4089505c170a375ed7097c218dfd71ea435a3c8ac
     volumes: [teable-data:/app/.assets:rw]
     env_file: [./.env-teable]
     environment: [NEXT_ENV_IMAGES_ALL_REMOTE=true]

--- a/services/tools.yml
+++ b/services/tools.yml
@@ -2,7 +2,7 @@
 services:
   ittools:
     profiles: [apps, all]
-    image: corentinth/it-tools:latest
+    image: corentinth/it-tools:2024.10.22-7ca5933
     networks: [traefik_public]
     labels:
       - traefik.enable=true

--- a/services/vert.yml
+++ b/services/vert.yml
@@ -2,7 +2,7 @@
 services:
   vert:
     profiles: [apps, all]
-    image: ghcr.io/vert-sh/vert:latest
+    image: ghcr.io/vert-sh/vert@sha256:c604d357e44dce6020391b6bd8d20e4f5d35e3778ecf58bbccbd8fdc6792eaf4
     restart: always
     environment:
       - PUB_HOSTNAME=vert.${DOMAIN:-traefik.me}


### PR DESCRIPTION
## What changed
This pins mutable Docker image references in the homelab compose files to concrete upstream versions.

It replaces refs such as `latest`, `release`, untagged images, and moving channel tags with explicit version tags. For a few registries that do not publish stable version tags for the current artifact, it pins by digest instead.

## Why
Mutable image refs make deployments non-reproducible and can change behavior unexpectedly between pulls. Pinning the current concrete image versions keeps the stack deterministic while still allowing Dependabot to handle periodic upgrades.

## Impact
Operators can now pull and deploy a stable, explicit set of container images.

Notable cases:
- Immich server and machine-learning were kept on the same verified release tag.
- Teable, Vert, and Alpine Chrome were pinned by digest because the upstream registries did not expose an equivalent stable version tag for the currently published artifact.

## Validation
- `DOMAIN=test.traefik.me docker compose --profile all config`
- Commit hooks passed during `git commit` (`check yaml`, `yamlfix`, and related pre-commit checks)
