### PR TITLE
[codex] Use built-in Immich healthchecks

### DIFF
--- a/services/immich.yml
+++ b/services/immich.yml
@@ -58,12 +58,6 @@ services:
       - homepage.icon=immich.png
       - homepage.href=https://photos.${DOMAIN:-traefik.me}
       - homepage.description=Family photo and video library
-    healthcheck:
-      test: [CMD, curl, -f, http://localhost:2283/api/server/ping]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
     restart: unless-stopped
     deploy:
       resources:
@@ -94,12 +88,6 @@ services:
       - REDIS_HOSTNAME=redis
       - IMMICH_WORKERS_EXCLUDE=api
     networks: [immich]
-    healthcheck:
-      test: [CMD, bash, -c, exec 5<>/dev/tcp/127.0.0.1/3002]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 60s
     restart: unless-stopped
     # deploy:
     #   resources:
@@ -120,12 +108,6 @@ services:
     volumes: [immich_model_cache:/cache]
     environment: [REDIS_HOSTNAME=redis]
     networks: [immich]
-    healthcheck:
-      test: [CMD, bash, -c, exec 5<>/dev/tcp/127.0.0.1/3003]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 120s
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
## What changed

Removed the custom healthcheck blocks for Immich server, microservices, and machine-learning in services/immich.yml so those containers use the healthchecks shipped in the current Immich images.

## Why

The repo-local checks had drifted from upstream behavior. In particular, microservices and machine-learning were using raw TCP probes to ports 3002 and 3003 instead of the image-defined checks, which led to misleading health failures and duplicated maintenance.

## Validation
- nix develop -c prek run -a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed automatic health monitoring from Immich services in Docker Compose deployments. The server, microservices, and machine-learning services will no longer be automatically probed for availability status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->